### PR TITLE
fix snyk DoS dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-           <!-- SNYK bug
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-beans</artifactId>
                 <version>5.3.20</version>
             </dependency>
-            -->
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
```
[INFO] Issues to fix by upgrading:
[INFO] 
[INFO]   Upgrade org.springframework.boot:spring-boot-starter-web@2.6.7 to org.springframework.boot:spring-boot-starter-web@2.6.8 to fix
[INFO]   ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313] in org.springframework:spring-beans@5.3.19
[INFO]     introduced by org.springframework.boot:spring-boot-starter-web@2.6.7 > org.springframework:spring-web@5.3.19 > org.springframework:spring-beans@5.3.19
```