### PR TITLE
use k8s

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                                 passwordVariable: 'CONTAINER_REGISTRY_PASSWORD',
                                 usernameVariable: 'CONTAINER_REGISTRY_USERNAME')]) {
                             sh (label: 'mvn deploy spring-boot:build-image',
-                                script: 'export OTEL_TRACES_EXPORTER="otlp" && ./mvnw -V -B deploy')
+                                script: 'export OTEL_TRACES_EXPORTER="otlp" && ./mvnw -V -B deploy -Dmaven.deploy.skip')
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,89 +1,25 @@
 pipeline {
-    agent { label 'linux' }
-    options {
-        disableConcurrentBuilds()
-        quietPeriod(15)
+    agent {
+        kubernetes {
+            yamlFile 'KubernetesPod.yaml'
+        }
     }
     stages {
-        stage('Checkout') {
-            steps {
-                echo 'cache checkout'
-                script {
-                    env.VERSION = newVersion()
-                }
-            }
-        }
         stage('Build') {
-            agent {
-                node {
-                    label 'linux'
-                    customWorkspace "${VERSION}"
-                }
-            }
             steps {
-                withCredentials([string(credentialsId: 'snyk.io', variable: 'SNYK_TOKEN')]) {
-                    withCredentials([
-                        usernamePassword(
-                            credentialsId: 'docker.io',
-                            passwordVariable: 'CONTAINER_REGISTRY_PASSWORD',
-                            usernameVariable: 'CONTAINER_REGISTRY_USERNAME')]) {
-                        sh (
-                        label: 'mvn deploy spring-boot:build-image',
-                        script: 'export OTEL_TRACES_EXPORTER="otlp" && ./mvnw -V -B deploy')
-                        // security disclosure
-                        //sh(label: 'security issue', script: 'echo "${CONTAINER_REGISTRY_PASSWORD}" > file.txt')
+                container('maven') {
+                    withCredentials([string(credentialsId: 'snyk.io', variable: 'SNYK_TOKEN')]) {
+                        withCredentials([
+                            usernamePassword(
+                                credentialsId: 'docker.io',
+                                passwordVariable: 'CONTAINER_REGISTRY_PASSWORD',
+                                usernameVariable: 'CONTAINER_REGISTRY_USERNAME')]) {
+                            sh (label: 'mvn deploy spring-boot:build-image',
+                                script: 'export OTEL_TRACES_EXPORTER="otlp" && ./mvnw -V -B deploy')
+                        }
                     }
                 }
-				/*
-                withCredentials([string(credentialsId: 'github', variable: 'GITHUB_TOKEN')]) {
-                    sh(label: 'security issue', script: 'echo "${GITHUB_TOKEN}" > file.txt')
-                }
-                sh(label: 'read password', script: 'cat file.txt')
-				*/
-            }
-            post {
-                failure {
-                    notifyBuild('danger')
-                }
-            }
-        }
-        stage('Deploy') {
-            steps {
-                build(job: 'antifraud/deploy-antifraud',
-                          parameters: [
-                            string(name: 'PREVIOUS_VERSION', value: previousVersion()),
-                            string(name: 'VERSION', value: newVersion())
-                      ])
             }
         }
     }
-}
-
-def previousVersion() {
-    def props = readProperties(file: 'versions.properties')
-    return props.CURRENT
-}
-
-def newVersion() {
-    def props = readProperties(file: 'versions.properties')
-    return props.NEW
-}
-
-def notifyBuild(status) {
-    def blocks =
-    [
-      [
-        "type": "section",
-        "text": [
-          "type": "mrkdwn",
-          "text": "The CI/CD build finished with status `${currentBuild.result}`\n\n<${env.OTEL_ELASTIC_URL}|View traces in OpenTelemetry>"
-        ],
-      "accessory": [
-        "type": "image",
-        "image_url": "https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/static/img/logos/opentelemetry-logo-nav.png",
-        "alt_text": "OpenTelemetry"
-      ]
-    ]
-  ]
-  slackSend(channel: "#cicd", blocks: blocks)
 }

--- a/KubernetesPod.yaml
+++ b/KubernetesPod.yaml
@@ -16,6 +16,8 @@ spec:
     env:
     - name: DOCKER_HOST
       value: tcp://localhost:2375
+    - name: MAVEN_CONFIG
+      value: ""
   - name: dind
     image: docker:20.10.12-dind
     securityContext:

--- a/KubernetesPod.yaml
+++ b/KubernetesPod.yaml
@@ -34,13 +34,13 @@ spec:
     volumeMounts:
       - name: docker-cache
         mountPath: /var/lib/docker
-volumes:
-  - name: docker-cache
-    emptyDir: {}
-resources:
-  limits:
-    cpu: 2
-    memory: 8Gi
-  requests:
-    cpu: 1
-    memory: 4Gi
+  volumes:
+    - name: docker-cache
+      emptyDir: {}
+  resources:
+    limits:
+      cpu: 2
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 4Gi

--- a/KubernetesPod.yaml
+++ b/KubernetesPod.yaml
@@ -8,7 +8,7 @@ spec:
     - name: CONTAINER_ENV_VAR
       value: jnlp
   - name: maven
-    image: maven:3.8.1-jdk-8
+    image: maven:3.6.3-jdk-11
     command:
     - sleep
     args:

--- a/KubernetesPod.yaml
+++ b/KubernetesPod.yaml
@@ -1,0 +1,46 @@
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  containers:
+  - name: jnlp
+    env:
+    - name: CONTAINER_ENV_VAR
+      value: jnlp
+  - name: maven
+    image: maven:3.8.1-jdk-8
+    command:
+    - sleep
+    args:
+    - 99d
+    env:
+    - name: DOCKER_HOST
+      value: tcp://localhost:2375
+  - name: dind
+    image: docker:20.10.12-dind
+    securityContext:
+      privileged: true
+    env:
+      - name: DOCKER_TLS_CERTDIR
+        value: ""
+    command:
+      - dockerd
+    args:
+      - -H tcp://localhost:2375
+      - -H unix:///var/run/docker.sock
+    ports:
+      - containerPort: 2375
+        hostIP: 127.0.0.1
+    volumeMounts:
+      - name: docker-cache
+        mountPath: /var/lib/docker
+volumes:
+  - name: docker-cache
+    emptyDir: {}
+resources:
+  limits:
+    cpu: 2
+    memory: 8Gi
+  requests:
+    cpu: 1
+    memory: 4Gi


### PR DESCRIPTION
### What

- Simplify pipeline (avoid notifications and deployments)
- Use k8s pod templates
- Run DinD so https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#build-image.docker-daemon can be used
- Avoid maven central deployment.

The existing k8s definition was found in:
- https://github.com/jenkinsci/kubernetes-plugin/blob/master/examples/declarative_from_yaml_file/KubernetesPod.yaml
- https://github.com/elastic/apm-pipeline-library/blob/784ee900eb116fd3a4fe887497fb9c0766d0de5a/resources/pods/dind-python.yml